### PR TITLE
Improve color contrast for text

### DIFF
--- a/app.css
+++ b/app.css
@@ -1,16 +1,20 @@
+:root {
+  --dark-red: #A8101C;
+}
+
 body {
     background: #f5d9d5;
     font-family: "Nunito", sans-serif;
 }
 
 .blurb h2 {
-   color: #EA1C2C;
+   color: var(--dark-red);
    font-weight: 100;
    font-size: 2.5rem;
 }
 
 .blurb p {
-    color: #f498b8;
+    color: #C11551;
     font-weight: 100;
     font-size: 1.125rem;
     line-height: 2;
@@ -23,27 +27,28 @@ body {
 
 #mainNavbar {
     font-size: 1.5rem;
-    font-weight: 100;    
+    font-weight: 100;
 }
 
 #mainNavbar .nav-link {
-    color: white;
+    color: #545454;
 }
 
 #mainNavbar .nav-link:hover {
-    color: #EA1C2C;
+    color: var(--dark-red);
 }
 
 #mainNavbar .navbar-brand {
-    color: #EA1C2C;
+    color: var(--dark-red);
     font-size: 1.5rem;
 }
 
 #headingGroup span {
-    color: #EA1C2C;
+    color: var(--dark-red);
 }
 
-#headingGroup h1 {
+#headingGroup {
+    color: #0C82B0 !important;
     font-weight: 100;
     font-size: 4rem;
 }
@@ -62,7 +67,3 @@ body {
         font-size: 2rem;
     }
 }
-
-
-
-

--- a/index.html
+++ b/index.html
@@ -44,13 +44,13 @@
     <div class="row align-items-center">
       <div class="col-lg-6">
         <div id="headingGroup" class="text-white text-center d-none d-lg-block mt-5">
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
-          <h1 class=>MUSEUM<span>/</span>OF<span>/</span>CANDY</h1>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
+          MUSEUM<span>/</span>OF<span>/</span>CANDY<br/>
         </div>
       </div>
       <div class="col-lg-6">


### PR DESCRIPTION
This pr makes several changes
- Made light pink text color, a lot less pink
- Made "musuem of candy" a dark blue, to keep some color in the page without going to black or grey
- Make dark red text darker
- Made nav links a grey, as the background on the nav gets even dark when scrolling
- Removed all the h1s for the "musuem of candy" section, as it'd make it hard to navigate page with so many implicit empty sections